### PR TITLE
Feature/content moderation state permission

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,116 @@
+### Documentation available at https://wodby.com/docs/stacks/drupal/local
+### Changelog can be found at https://github.com/wodby/docker4drupal/releases
+### Images tags format explained at https://github.com/wodby/docker4drupal#images-tags
+
+### PROJECT SETTINGS
+
+PROJECT_NAME=omh
+PROJECT_BASE_URL=omh.lndo.site
+PROJECT_PORT=80
+
+DB_NAME=drupal
+DB_USER=drupal
+DB_PASSWORD=drupal
+DB_ROOT_PASSWORD=password
+DB_HOST=mariadb
+DB_PORT=3306
+DB_DRIVER=mysql
+
+### --- MARIADB ----
+
+MARIADB_TAG=10.11-3.28.2
+#MARIADB_TAG=11.2-3.28.2
+#MARIADB_TAG=11.1-3.28.2
+#MARIADB_TAG=11.0-3.28.2
+#MARIADB_TAG=10.6-3.28.2
+#MARIADB_TAG=10.5-3.28.2
+#MARIADB_TAG=10.4-3.28.2
+
+### --- VANILLA DRUPAL ----
+
+DRUPAL_TAG=10-4.67.0
+#DRUPAL_TAG=7-4.67.0
+
+### --- PHP ----
+
+# Linux (uid 1000 gid 1000)
+
+#PHP_TAG=8.3-dev-4.55.0
+#PHP_TAG=8.2-dev-4.55.0
+PHP_TAG=8.1-dev-4.55.0
+
+# macOS (uid 501 gid 20)
+
+#PHP_TAG=8.3-dev-macos-4.55.0
+#PHP_TAG=8.2-dev-macos-4.55.0
+#PHP_TAG=8.1-dev-macos-4.55.0
+
+### --- NGINX ----
+
+NGINX_TAG=1.25-5.34.2
+#NGINX_TAG=1.24-5.34.2
+#NGINX_TAG=1.25-5.34.2
+
+NGINX_VHOST_PRESET=drupal10
+#NGINX_VHOST_PRESET=drupal9
+#NGINX_VHOST_PRESET=drupal8
+#NGINX_VHOST_PRESET=drupal7
+
+### --- SOLR ---
+
+SOLR_TAG=8-4.18.2
+#SOLR_TAG=7-4.18.2
+#SOLR_TAG=6-4.18.2
+#SOLR_TAG=5-4.18.2
+
+SOLR_CONFIG_SET="search_api_solr_4.1.6"
+#SOLR_CONFIG_SET="search_api_solr_4.0.1"
+#SOLR_CONFIG_SET="search_api_solr_8.x-3.9"
+#SOLR_CONFIG_SET="search_api_solr_8.x-3.2"
+#SOLR_CONFIG_SET="search_api_solr_8.x-2.7"
+#SOLR_CONFIG_SET="search_api_solr_8.x-1.2"
+#SOLR_CONFIG_SET="search_api_solr_7.x-1.14"
+
+### --- ELASTICSEARCH ---
+
+ELASTICSEARCH_TAG=7-5.19.4
+
+### --- KIBANA ---
+
+KIBANA_TAG=7-5.19.4
+
+### --- REDIS ---
+
+REDIS_TAG=7-4.4.2
+#REDIS_TAG=6-4.4.2
+
+### --- NODE ---
+
+NODE_TAG=20-dev-1.31.2
+#NODE_TAG=18-dev-1.31.2
+
+### --- VARNISH ---
+
+VARNISH_TAG=6.0-4.16.1
+
+### --- POSTGRESQL ----
+
+POSTGRES_TAG=16-1.33.2
+#POSTGRES_TAG=15-1.33.2
+#POSTGRES_TAG=14-1.33.2
+#POSTGRES_TAG=13-1.33.2
+#POSTGRES_TAG=12-1.33.2
+
+### OTHERS
+
+ADMINER_TAG=4-3.24.4
+APACHE_TAG=2.4-4.13.1
+ATHENAPDF_TAG=2.16.0
+DRUPAL_NODE_TAG=1.0-2.0.0
+MEMCACHED_TAG=1-2.16.3
+OPENSMTPD_TAG=6-1.20.1
+RSYSLOG_TAG=latest
+SELENIUM_CHROME_TAG=3.141
+WEBGRIND_TAG=1-1.30.1
+XHPROF_TAG=3.7.6
+ZOOKEEPER_TAG=3.8

--- a/web/modules/custom/cmsp/cmsp.info.yml
+++ b/web/modules/custom/cmsp/cmsp.info.yml
@@ -1,0 +1,5 @@
+name: Content Moderation State Permissions
+type: module
+description: 'Provides granular permissions for viewing revisions based on their Content Moderation State.'
+package: Content Moderation
+core_version_requirement: ^10

--- a/web/modules/custom/cmsp/cmsp.module
+++ b/web/modules/custom/cmsp/cmsp.module
@@ -1,0 +1,23 @@
+<?php
+
+use Drupal\content_moderation\ContentModerationState;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityPublishedInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\workflows\WorkflowInterface;
+
+function cmsp_entity_access(EntityInterface $entity, $operation, AccountInterface $account) {
+  $access_result = NULL;
+  /** @var \Drupal\content_moderation\ModerationInformationInterface $moderation_info */
+  $moderation_info = Drupal::service('content_moderation.moderation_information');
+  if ($operation === 'view') {
+    if (($entity instanceof EntityPublishedInterface) && !$entity->isPublished() && $moderation_info->isModeratedEntity($entity) && $entity->moderation_state) {
+      $workflow = $moderation_info->getWorkflowForEntity($entity);
+      /** @var ContentModerationState $state */
+      $state = $entity->get('moderation_state')->value;
+      $access_result = AccessResult::allowedIfHasPermission($account, 'View revisions in ' . $workflow->id() . ' state ' . $state);
+    }
+  }
+  return $access_result;
+}

--- a/web/modules/custom/cmsp/cmsp.permissions.yml
+++ b/web/modules/custom/cmsp/cmsp.permissions.yml
@@ -1,0 +1,2 @@
+permission_callbacks:
+  - \Drupal\cmsp\ContentModerationStatePermissions::permissions

--- a/web/modules/custom/cmsp/src/ContentModerationStatePermissions.php
+++ b/web/modules/custom/cmsp/src/ContentModerationStatePermissions.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\cmsp;
+
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\workflows\Entity\Workflow;
+use Drupal\workflows\WorkflowInterface;
+use Drupal\content_moderation\ContentModerationState;
+
+class ContentModerationStatePermissions {
+  use StringTranslationTrait;
+
+  /**
+   * Returns an array of state permissions.
+   *
+   * @return array
+   *   The state permissions.
+   */
+  public function permissions() {
+    $permissions = [];
+    /** @var WorkflowInterface $workflow */
+    foreach (Workflow::loadMultipleByType('content_moderation') as $workflow) {
+      /** @var ContentModerationState $state */
+      foreach ($workflow->getTypePlugin()->getStates() as $state) {
+        if ($state->isPublishedState()) {
+          // We don't need to control access to published states.
+          continue;
+        }
+        $permissions['View revisions in ' . $workflow->id() . ' state ' . $state->id()] = [
+          'title' => $this->t('%workflow workflow: View %state state.', [
+            '%workflow' => $workflow->label(),
+            '%state' => $state->label(),
+          ]),
+          'description' => $this->t('View content revisions in %state state.', ['%state' => $state->label()]),
+          'dependencies' => [
+            $workflow->getConfigDependencyKey() => [$workflow->getConfigDependencyName()],
+          ],
+        ];
+      }
+    }
+
+    return $permissions;
+  }
+}


### PR DESCRIPTION
If you pull this branch and move the cmsp module folder over to /web/modules/custom on the main repo you can then enable and test it 

It creates permissions for any workflow state that's available. You can then grant viewing permissions for that state to any role. 

Anyone with that role will be able to view a content revision in that state. 